### PR TITLE
Provide better error response when template parsing fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "dependencies": {
-    "htm": "^3.0.4",
+    "htm": "^3.1.0",
     "vhtml": "^2.2.0"
   },
   "devDependencies": {

--- a/src/lib/mtl.test.ts
+++ b/src/lib/mtl.test.ts
@@ -1,0 +1,13 @@
+import { html } from './mtl';
+
+describe('createClassListPropertySource', () => {
+  it('should render a basic block of html', () => {
+    expect(html`<div data-test="${'bar'}">foo</div>`).toEqual(`<div data-test="bar">foo</div>`);
+  });
+
+  it('should throw a descriptive parse error', () => {
+    expect(() => html`<div data-test="${'bar'}"<span>foo</span></div>`).toThrowError(
+      'Error parsing muban template. Most likely, your html template is malformed',
+    );
+  });
+});

--- a/src/lib/mtl.ts
+++ b/src/lib/mtl.ts
@@ -13,5 +13,15 @@ function h(type: any, props: Record<string, any>, ...children: Array<any>) {
   return vhtml(type, props, children);
 }
 
-// the template tag to render HTML strings in muban templats
-export const html = htm.bind(h);
+// the template tag to render HTML strings in muban templates
+export const html = (strings: TemplateStringsArray, ...values: Array<any>): any => {
+  try {
+    return htm.bind(h)(strings, ...values);
+  } catch (e) {
+    // throw a custom error message, since the built-in html parse errors are not useful at all
+    throw new Error(`Error parsing muban template. Most likely, your html template is malformed.
+
+The template that gave the error is:
+${strings.join('${}')}`);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8593,10 +8593,10 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-htm@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/htm/-/htm-3.0.4.tgz#c90c891645d2d792bdb9f8c867964b18e3503718"
-  integrity sha512-VRdvxX3tmrXuT/Ovt59NMp/ORMFi4bceFMDjos1PV4E0mV+5votuID8R60egR9A4U8nLt238R/snlJGz3UYiTQ==
+htm@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/htm/-/htm-3.1.0.tgz#0c305493b60da9f6ed097a2aaf4c994bd85ea022"
+  integrity sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q==
 
 html-comment-regex@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
Add a wrapper around the export to catch errors and output the template
where the error happened.

Also add basic unit tests.

Example error:
```
    Error parsing muban template. Most likely, your html template is malformed.

    The template that gave the error is:
    <div data-test="${}"<span>foo</span></div>
```

fixes #2